### PR TITLE
feat: add support for mixed geometries

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install geom-merge
 import merge from "geom-merge";
 import { cube, sphere } from "primitive-geometry";
 
-const geometry = merge([cube, sphere]);
+const geometry = merge([cube(), sphere()]);
 ```
 
 ## API
@@ -29,9 +29,9 @@ const geometry = merge([cube, sphere]);
 
 **Returns**
 
-geometry: `{ positions: TypedArray|Array, cells: TypedArray|Array, ...otherAttributesMerged: TypedArray|Array }` - new geometry with merged attributes and cells from provided geometries.
+geometry: `{ positions: TypedArray | Array | Array<[x, y, z]>, cells: TypedArray | Array | Array<[a, b, c]>, ...otherAttributesMergedAndFlattened: TypedArray | Array }` - new geometry with cells, and merged/flattened attributes.
 
-_Note 1: Each geometry object requires at least `positions` and `cells`. Other properties like `uvs` or `normals` will be merged as well if available in all geometries._
+_Note 1: Each geometry object requires at least `positions` and `cells`. Other array-like properties like `uvs` or `normals` will be merged and flattened, if available in all geometries. Cells will be chunked if any of the geometries has chunked cells._
 
 _Note 2: This module doesn't perform CSG operations_
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -45,30 +45,30 @@ oldCubeGeometry.oldCubeExtra = [];
 let geometry;
 // Single geometry
 geometry = merge([{ ...sphereGeometry }]);
-geometry = merge([{ ...oldSphereGeometry }]);
+// geometry = merge([{ ...oldSphereGeometry }]);
 
-// Flat typed array geometries
-geometry = merge([
-  { ...sphereGeometry },
-  { ...cubeGeometry },
-  // cube({ sx: 2, sy: 0.5, sz: 0.5, nx: 200, ny: 200, nz: 200 }), // Testing cells Uint16/32 scaling
-]);
+// // Flat typed array geometries
+// geometry = merge([
+//   { ...sphereGeometry },
+//   { ...cubeGeometry },
+//   // cube({ sx: 2, sy: 0.5, sz: 0.5, nx: 200, ny: 200, nz: 200 }), // Testing cells Uint16/32 scaling
+// ]);
 
-// Flat array geometries
-geometry = merge([
-  propertiesArrayFrom({ ...sphereGeometry }),
-  // sphere()
-  propertiesArrayFrom({ ...cubeGeometry }),
-]);
+// // Flat array geometries
+// geometry = merge([
+//   propertiesArrayFrom({ ...sphereGeometry }),
+//   // sphere()
+//   propertiesArrayFrom({ ...cubeGeometry }),
+// ]);
 
-// Chunked array geometries
-geometry = merge([{ ...oldSphereGeometry }, { ...oldCubeGeometry }]);
+// // Chunked array geometries
+// geometry = merge([{ ...oldSphereGeometry }, { ...oldCubeGeometry }]);
 
-// Mixed flat geometries
-geometry = merge([
-  { ...oldSphereGeometry },
-  propertiesArrayFrom({ ...cubeGeometry }),
-]);
+// // Mixed flat geometries
+// geometry = merge([
+//   { ...oldSphereGeometry },
+//   propertiesArrayFrom({ ...cubeGeometry }),
+// ]);
 // Mixed flat and chunked geometries: not supported
 // geometry = merge([{ ...oldSphereGeometry }, { ...cubeGeometry }]);
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -19,14 +19,59 @@ const camera = createCamera({
 });
 const orbiter = createOrbiter({ camera });
 
+const propertiesArrayFrom = (obj) =>
+  Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [
+      key,
+      typeof value !== "string" ? Array.from(value) : value,
+    ]),
+  );
+
+// Geometries
+const sphereGeometry = sphere();
+sphereGeometry.name = `sphereGeometry`;
+const cubeGeometry = cube({ sx: 2, sy: 0.5, sz: 0.5 });
+cubeGeometry.name = `cubeGeometry`;
+const oldSphereGeometry = oldSphere(0.5);
+oldSphereGeometry.name = `oldSphereGeometry`;
+const oldCubeGeometry = oldCube(2, 0.5, 0.5);
+oldCubeGeometry.name = `oldCubeGeometry`;
+
+sphereGeometry.sphereExtra = [];
+cubeGeometry.cubeExtra = [];
+oldSphereGeometry.oldSphereExtra = [];
+oldCubeGeometry.oldCubeExtra = [];
+
 let geometry;
-// geometry = sphere();
+// Single geometry
+geometry = merge([{ ...sphereGeometry }]);
+geometry = merge([{ ...oldSphereGeometry }]);
+
+// Flat typed array geometries
 geometry = merge([
-  sphere(),
-  cube({ sx: 2, sy: 0.5, sz: 0.5 }),
+  { ...sphereGeometry },
+  { ...cubeGeometry },
   // cube({ sx: 2, sy: 0.5, sz: 0.5, nx: 200, ny: 200, nz: 200 }), // Testing cells Uint16/32 scaling
 ]);
-// geometry = merge([oldCube(2, 0.5, 0.5), oldSphere(0.5)]);
+
+// Flat array geometries
+geometry = merge([
+  propertiesArrayFrom({ ...sphereGeometry }),
+  // sphere()
+  propertiesArrayFrom({ ...cubeGeometry }),
+]);
+
+// Chunked array geometries
+geometry = merge([{ ...oldSphereGeometry }, { ...oldCubeGeometry }]);
+
+// Mixed flat geometries
+geometry = merge([
+  { ...oldSphereGeometry },
+  propertiesArrayFrom({ ...cubeGeometry }),
+]);
+// Mixed flat and chunked geometries: not supported
+// geometry = merge([{ ...oldSphereGeometry }, { ...cubeGeometry }]);
+
 console.log(geometry);
 
 const clearCmd = {

--- a/index.js
+++ b/index.js
@@ -119,19 +119,19 @@ function merge(geometries) {
 
       if (attribute === "cells") {
         if (areAllCellsFlatArray) {
-          mergedGeometry.cells = areAllCellsTypedArray
-            ? typedArrayConcat(
-                CellsConstructor,
-                mergedGeometry.cells,
-                // Add previous geometry vertex offset mapped via a new typed array
-                // because new value could be larger than what current type supports
-                new (typedArrayConstructor(vertexOffset + positionCount))(
-                  geometry.cells,
-                ).map((n) => vertexOffset + n),
-              )
-            : mergedGeometry.cells.concat(
-                geometry.cells.map((n) => vertexOffset + n),
-              );
+          if (areAllCellsTypedArray) {
+            mergedGeometry.cells = typedArrayConcat(
+              CellsConstructor,
+              mergedGeometry.cells,
+              // Add previous geometry vertex offset mapped via a new typed array
+              // because new value could be larger than what current type supports
+              new CellsConstructor(geometry.cells).map((n) => vertexOffset + n),
+            );
+          } else {
+            mergedGeometry.cells = mergedGeometry.cells.concat(
+              geometry.cells.map((n) => vertexOffset + n),
+            );
+          }
         } else {
           mergedGeometry.cells = mergedGeometry.cells.concat(
             // Chunk flat cells if needed
@@ -149,15 +149,15 @@ function merge(geometries) {
           ? geometry[attribute]
           : geometry[attribute].flat();
 
-        mergedGeometry[attribute] = isAttributeTypedArray(
-          mergedGeometry[attribute],
-        )
-          ? typedArrayConcat(
-              mergedGeometry[attribute].constructor,
-              mergedGeometry[attribute],
-              values,
-            )
-          : mergedGeometry[attribute].concat(values);
+        if (isAttributeTypedArray(mergedGeometry[attribute])) {
+          mergedGeometry[attribute] = typedArrayConcat(
+            mergedGeometry[attribute].constructor,
+            mergedGeometry[attribute],
+            values,
+          );
+        } else {
+          mergedGeometry[attribute] = mergedGeometry[attribute].concat(values);
+        }
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -1,17 +1,108 @@
 import typedArrayConcat from "typed-array-concat";
 import typedArrayConstructor from "typed-array-constructor";
 
-function merge(geometries) {
-  const isTypedArray = !Array.isArray(geometries[0].positions);
+const isAttributeFlat = (attribute) => !attribute[0]?.length;
 
-  const CellsConstructor = isTypedArray
-    ? typedArrayConstructor(
-        geometries.reduce(
-          (sum, geometry) =>
-            sum + geometry.positions.length / (isTypedArray ? 3 : 1),
-          0
-        )
-      )
+const isAttributeTypedArray = (attribute) => !(attribute instanceof Array);
+
+const isAttributeArrayLike = (attribute) =>
+  Array.isArray(attribute) || ArrayBuffer.isView(attribute);
+
+const getGeometryAttributes = (geometry) =>
+  Object.keys(geometry).filter((attribute) =>
+    isAttributeArrayLike(geometry[attribute]),
+  );
+
+function chunkAndOffset(array, stride, offset) {
+  const result = [];
+  let chunk = [];
+  for (let i = 0; i < array.length; i++) {
+    chunk.push(array[i] + offset);
+    if (i % stride === stride - 1) {
+      result.push(chunk);
+      chunk = [];
+    }
+  }
+  if (chunk.length) {
+    console.warn(
+      `Array length (${array.length}) is not a multiple of stride "${stride}".`,
+    );
+    result.push(chunk);
+  }
+  return result;
+}
+
+const meta = Symbol("geom-merge-meta");
+
+function merge(geometries) {
+  let mergedPositionCount = 0;
+  let areAllCellsFlatArray = true;
+  let areAllCellsTypedArray = true;
+
+  // Set mergeable attributes from first geometry
+  const initialAttributes = getGeometryAttributes(geometries[0]);
+  let mergeableAttributes = [...initialAttributes];
+
+  // Collect cells type, position count and filter mergeable attributes
+  for (let i = 0; i < geometries.length; i++) {
+    const geometry = geometries[i];
+
+    if (i > 0) {
+      const attributes = getGeometryAttributes(geometry);
+
+      // Check if geometry has all the first geometry attributes
+      for (let j = 0; j < initialAttributes.length; j++) {
+        const initialAttribute = initialAttributes[j];
+
+        if (!attributes.includes(initialAttribute)) {
+          console.warn(
+            `geom-merge: geometry "${geometry.name || i}" is missing attribute ${initialAttribute}.`,
+          );
+
+          // Remove the attribute from the list of mergeable attributes
+          mergeableAttributes = mergeableAttributes.filter(
+            (attribute) => attribute !== initialAttribute,
+          );
+        }
+      }
+
+      // Check if geometry has all the previous geometry attributes
+      const extraAttributes = attributes.filter(
+        (attribute) => !mergeableAttributes.includes(attribute),
+      );
+      if (extraAttributes.length) {
+        console.warn(
+          `geom-merge: geometry "${geometry.name || i}" has extra attributes: ${extraAttributes.join(", ")}.`,
+        );
+      }
+    }
+
+    const positionCount =
+      geometry.positions.length / (isAttributeFlat(geometry.positions) ? 3 : 1);
+
+    const isCellsFlatArray = isAttributeFlat(geometry.cells);
+
+    // Store attribute properties reused in the next loop
+    geometry[meta] = { positionCount, isCellsFlatArray };
+
+    // Increment/update properties used to determine cells type
+    mergedPositionCount += positionCount;
+    areAllCellsFlatArray &&= isCellsFlatArray;
+    areAllCellsTypedArray &&= isAttributeTypedArray(geometry.cells);
+  }
+
+  // Check if first geometry has extra attributes
+  const extraAttributes = initialAttributes.filter(
+    (initialAttribute) => !mergeableAttributes.includes(initialAttribute),
+  );
+  if (extraAttributes.length) {
+    console.warn(
+      `geom-merge: geometry "${geometries[0].name || "0"}" has extra attributes: ${extraAttributes.join(", ")}.`,
+    );
+  }
+
+  const CellsConstructor = areAllCellsTypedArray
+    ? typedArrayConstructor(mergedPositionCount)
     : Array;
 
   const mergedGeometry = { cells: new CellsConstructor() };
@@ -21,41 +112,58 @@ function merge(geometries) {
   for (let i = 0; i < geometries.length; i++) {
     const geometry = geometries[i];
 
-    const vertexCount = geometry.positions.length / (isTypedArray ? 3 : 1);
+    const { positionCount, isCellsFlatArray } = geometry[meta];
 
-    for (let attribute of Object.keys(geometry)) {
+    for (let j = 0; j < mergeableAttributes.length; j++) {
+      const attribute = mergeableAttributes[j];
+
       if (attribute === "cells") {
-        mergedGeometry.cells = isTypedArray
-          ? typedArrayConcat(
-              CellsConstructor,
-              mergedGeometry.cells,
-              // Add previous geometry vertex offset mapped via a new typed array
-              // because new value could be larger than what current type supports
-              new (typedArrayConstructor(vertexOffset + vertexCount))(
-                geometry.cells
-              ).map((n) => vertexOffset + n)
-            )
-          : mergedGeometry.cells.concat(
-              geometry.cells.map((cell) => cell.map((n) => vertexOffset + n))
-            );
+        if (areAllCellsFlatArray) {
+          mergedGeometry.cells = areAllCellsTypedArray
+            ? typedArrayConcat(
+                CellsConstructor,
+                mergedGeometry.cells,
+                // Add previous geometry vertex offset mapped via a new typed array
+                // because new value could be larger than what current type supports
+                new (typedArrayConstructor(vertexOffset + positionCount))(
+                  geometry.cells,
+                ).map((n) => vertexOffset + n),
+              )
+            : mergedGeometry.cells.concat(
+                geometry.cells.map((n) => vertexOffset + n),
+              );
+        } else {
+          mergedGeometry.cells = mergedGeometry.cells.concat(
+            // Chunk flat cells if needed
+            isCellsFlatArray
+              ? chunkAndOffset(geometry.cells, 3, vertexOffset)
+              : geometry.cells.map((cell) => cell.map((n) => vertexOffset + n)),
+          );
+        }
       } else {
-        const isAttributeTypedArray = !Array.isArray(geometry[attribute]);
+        // Create the merged attribute from first geometry type
+        mergedGeometry[attribute] ||= new geometry[attribute].constructor();
 
-        mergedGeometry[attribute] ||= isAttributeTypedArray
-          ? new geometry[attribute].constructor()
-          : [];
+        // Enforce returning flat arrays
+        const values = isAttributeFlat(geometry[attribute])
+          ? geometry[attribute]
+          : geometry[attribute].flat();
 
-        mergedGeometry[attribute] = isAttributeTypedArray
+        mergedGeometry[attribute] = isAttributeTypedArray(
+          mergedGeometry[attribute],
+        )
           ? typedArrayConcat(
               mergedGeometry[attribute].constructor,
               mergedGeometry[attribute],
-              geometry[attribute]
+              values,
             )
-          : mergedGeometry[attribute].concat(geometry[attribute]);
+          : mergedGeometry[attribute].concat(values);
       }
     }
 
-    vertexOffset += vertexCount;
+    vertexOffset += positionCount;
+
+    delete geometry[meta];
   }
 
   return mergedGeometry;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "typed-array-constructor": "^1.0.1"
       },
       "devDependencies": {
-        "es-module-shims": "^1.6.3",
+        "es-module-shims": "^1.8.3",
         "pex-cam": "^3.0.0-alpha.1",
         "pex-context": "^3.0.0-alpha.6",
-        "pex-math": "^4.0.0-alpha.3",
+        "pex-math": "^4.1.0",
         "primitive-cube": "^2.0.1",
-        "primitive-geometry": "^2.9.1",
+        "primitive-geometry": "^2.10.0",
         "primitive-sphere": "^3.0.0"
       },
       "engines": {
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/es-module-shims": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.6.3.tgz",
-      "integrity": "sha512-+BQyPRZczeV9JH/17X1nu1GbD+SZvdPKD4Nrt2S61J94A2yc8DpWBlzv9KgF9cOXUZKifEShy8/qLelSVNo/rA==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.8.3.tgz",
+      "integrity": "sha512-NOE2WomYkoXeae8FcwPwZApxDwKerEWGOiqNo/P2JCBkJgKCLA5+PMZs8sr/1SPk9a8E+hUE9Wc+YZyGEiWHkw==",
       "dev": true
     },
     "node_modules/gl-mat4": {
@@ -126,13 +126,13 @@
       }
     },
     "node_modules/pex-math": {
-      "version": "4.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/pex-math/-/pex-math-4.0.0-alpha.3.tgz",
-      "integrity": "sha512-4rHCFNLQnk/NHAQczW/VCBiXOPN2DvAjYhZw5EnEadtMLoI9tGQWd4JxANeV1i3O17PdfIoTi9ECfIRRkz8nwg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/pex-math/-/pex-math-4.1.0.tgz",
+      "integrity": "sha512-rpb92xRnGan4qOh0cXk8kD4GXXvt6ntQykkegjSU186pJ6uGJ/UJJ3amt9SQenmiEQHU2SXKvZImyzo1RTX61w==",
       "dev": true,
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=20.0.0",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/primitive-cube": {
@@ -142,9 +142,9 @@
       "dev": true
     },
     "node_modules/primitive-geometry": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/primitive-geometry/-/primitive-geometry-2.9.1.tgz",
-      "integrity": "sha512-qImUPQPio/CwQX6w52q11T31Z3G0TDJUbiOwt/h8JL3OSqhwHCFPurT/fTwLrCjiFMmxnhjxT+EA5NGIUaKJRA==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/primitive-geometry/-/primitive-geometry-2.10.0.tgz",
+      "integrity": "sha512-i+CQy51EDEU9zal/GRqOXfZeKo9MccM6SIOMM7+OkCCYqCFhetM7nLP3Ms7lDgtZjpIXp8iZI4TrXCqTfxADWA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -33,16 +33,16 @@
     "typed-array-constructor": "^1.0.1"
   },
   "devDependencies": {
-    "es-module-shims": "^1.6.3",
+    "es-module-shims": "^1.8.3",
     "pex-cam": "^3.0.0-alpha.1",
     "pex-context": "^3.0.0-alpha.6",
-    "pex-math": "^4.0.0-alpha.3",
+    "pex-math": "^4.1.0",
     "primitive-cube": "^2.0.1",
-    "primitive-geometry": "^2.9.1",
+    "primitive-geometry": "^2.10.0",
     "primitive-sphere": "^3.0.0"
   },
   "engines": {
-    "node": ">=18.0.0",
-    "npm": ">=8.0.0"
+    "node": ">=20.0.0",
+    "npm": ">=9.6.4"
   }
 }


### PR DESCRIPTION
- [x] support geometries with different cells types
- [x] geometries with different attributes types (flat uvs and chunks uvs) are flattened
- [x] support returning [] instead of CellsConstructor for flat arrays
- [x] Check geometry attributes are array like before concatenating them #3
- [x] Add warnings for missing attributes #4

Closes #3
Closes #4

BREAKING CHANGE: returned geometries attributes are flattened